### PR TITLE
Implement MIDI profiles system with device-specific presets

### DIFF
--- a/src/LiveCompanion.Core/Interfaces/IMidiEngine.cs
+++ b/src/LiveCompanion.Core/Interfaces/IMidiEngine.cs
@@ -19,10 +19,16 @@ public interface IMidiEngine
     IReadOnlyList<string> GetAvailablePorts();
 
     /// <summary>
-    /// Envoie un événement MIDI immédiatement sur le device spécifié dans l'événement.
+    /// Envoie un événement MIDI en résolvant les ports/canaux depuis les profils référencés.
+    /// Le message est envoyé une fois par profil ciblé.
     /// </summary>
-    /// <param name="midiEvent">Événement MIDI à envoyer.</param>
-    Task SendEventAsync(MidiEvent midiEvent);
+    Task SendEventAsync(MidiEvent midiEvent, IReadOnlyList<MidiProfile> profiles);
+
+    /// <summary>
+    /// Envoie un message MIDI directement sur un port et canal spécifiques.
+    /// Utilisé pour les tests de configuration (sans passer par les profils).
+    /// </summary>
+    Task SendDirectAsync(MidiEventType type, string deviceOut, int channel, int data1, int data2);
 
     /// <summary>Libère les ressources du moteur MIDI.</summary>
     Task ShutdownAsync();

--- a/src/LiveCompanion.Core/Models/AppSettings.cs
+++ b/src/LiveCompanion.Core/Models/AppSettings.cs
@@ -16,4 +16,7 @@ public class AppSettings
     /// Valeur par défaut : 3.
     /// </summary>
     public int CountdownBars { get; set; } = 3;
+
+    /// <summary>Presets MIDI réutilisables (raccourcis de configuration).</summary>
+    public List<MidiPreset> MidiPresets { get; set; } = [];
 }

--- a/src/LiveCompanion.Core/Models/AppSettings.cs
+++ b/src/LiveCompanion.Core/Models/AppSettings.cs
@@ -17,6 +17,6 @@ public class AppSettings
     /// </summary>
     public int CountdownBars { get; set; } = 3;
 
-    /// <summary>Presets MIDI réutilisables (raccourcis de configuration).</summary>
-    public List<MidiPreset> MidiPresets { get; set; } = [];
+    /// <summary>Profils MIDI par appareil (ex : "Quad Cortex") avec raccourcis prédéfinis.</summary>
+    public List<MidiProfile> MidiProfiles { get; set; } = [];
 }

--- a/src/LiveCompanion.Core/Models/MidiEvent.cs
+++ b/src/LiveCompanion.Core/Models/MidiEvent.cs
@@ -11,11 +11,8 @@ public class MidiEvent
     /// <summary>Type d'événement MIDI.</summary>
     public MidiEventType Type { get; set; } = MidiEventType.ProgramChange;
 
-    /// <summary>Nom du port/device MIDI de sortie cible.</summary>
-    public string DeviceOut { get; set; } = string.Empty;
-
-    /// <summary>Canal MIDI (1–16).</summary>
-    public int Channel { get; set; } = 1;
+    /// <summary>Identifiants des profils MIDI ciblés (multi-select).</summary>
+    public List<Guid> ProfileIds { get; set; } = [];
 
     /// <summary>
     /// Premier octet de données (numéro de programme, numéro de CC, numéro de note…).

--- a/src/LiveCompanion.Core/Models/MidiPreset.cs
+++ b/src/LiveCompanion.Core/Models/MidiPreset.cs
@@ -15,9 +15,6 @@ public class MidiPreset
     /// <summary>Type d'événement MIDI.</summary>
     public MidiEventType Type { get; set; } = MidiEventType.ControlChange;
 
-    /// <summary>Canal MIDI (1–16).</summary>
-    public int Channel { get; set; } = 1;
-
     /// <summary>Premier octet de données (numéro de CC, numéro de note…).</summary>
     public int Data1 { get; set; }
 

--- a/src/LiveCompanion.Core/Models/MidiPreset.cs
+++ b/src/LiveCompanion.Core/Models/MidiPreset.cs
@@ -1,0 +1,26 @@
+namespace LiveCompanion.Core.Models;
+
+/// <summary>
+/// Preset MIDI réutilisable (ex : "QC Footswitch A" → ControlChange CC35 ch.1).
+/// Ne contient ni Position ni DeviceOut, qui sont spécifiques au contexte d'utilisation.
+/// </summary>
+public class MidiPreset
+{
+    /// <summary>Identifiant unique du preset.</summary>
+    public Guid Id { get; init; } = Guid.NewGuid();
+
+    /// <summary>Nom affiché dans l'interface (ex : "QC Footswitch A").</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Type d'événement MIDI.</summary>
+    public MidiEventType Type { get; set; } = MidiEventType.ControlChange;
+
+    /// <summary>Canal MIDI (1–16).</summary>
+    public int Channel { get; set; } = 1;
+
+    /// <summary>Premier octet de données (numéro de CC, numéro de note…).</summary>
+    public int Data1 { get; set; }
+
+    /// <summary>Second octet de données (valeur CC, vélocité…).</summary>
+    public int Data2 { get; set; }
+}

--- a/src/LiveCompanion.Core/Models/MidiProfile.cs
+++ b/src/LiveCompanion.Core/Models/MidiProfile.cs
@@ -1,0 +1,16 @@
+namespace LiveCompanion.Core.Models;
+
+/// <summary>
+/// Profil MIDI représentant un appareil (ex : "Quad Cortex") avec ses raccourcis prédéfinis.
+/// </summary>
+public class MidiProfile
+{
+    /// <summary>Identifiant unique du profil.</summary>
+    public Guid Id { get; init; } = Guid.NewGuid();
+
+    /// <summary>Nom du profil / appareil (ex : "Quad Cortex").</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Raccourcis MIDI associés à cet appareil.</summary>
+    public List<MidiPreset> Presets { get; set; } = [];
+}

--- a/src/LiveCompanion.Core/Models/MidiProfile.cs
+++ b/src/LiveCompanion.Core/Models/MidiProfile.cs
@@ -11,6 +11,9 @@ public class MidiProfile
     /// <summary>Nom du profil / appareil (ex : "Quad Cortex").</summary>
     public string Name { get; set; } = string.Empty;
 
+    /// <summary>Port MIDI de sortie associé à cet appareil (ex : "MIDI OUT 3").</summary>
+    public string? DeviceOut { get; set; }
+
     /// <summary>Raccourcis MIDI associés à cet appareil.</summary>
     public List<MidiPreset> Presets { get; set; } = [];
 }

--- a/src/LiveCompanion.Core/Models/MidiProfile.cs
+++ b/src/LiveCompanion.Core/Models/MidiProfile.cs
@@ -14,6 +14,9 @@ public class MidiProfile
     /// <summary>Port MIDI de sortie associé à cet appareil (ex : "MIDI OUT 3").</summary>
     public string? DeviceOut { get; set; }
 
+    /// <summary>Canal MIDI par défaut pour cet appareil (1–16).</summary>
+    public int DefaultChannel { get; set; } = 1;
+
     /// <summary>Raccourcis MIDI associés à cet appareil.</summary>
     public List<MidiPreset> Presets { get; set; } = [];
 }

--- a/src/LiveCompanion.Core/Validation/ModelValidator.cs
+++ b/src/LiveCompanion.Core/Validation/ModelValidator.cs
@@ -82,10 +82,6 @@ public static class ModelValidator
             var e = song.MidiEvents[i];
             var prefix = $"MidiEvents[{i}]";
 
-            if (e.Channel < 1 || e.Channel > 16)
-                result.AddError($"{prefix}.Channel",
-                    $"Le canal MIDI doit être entre 1 et 16 (actuel : {e.Channel}).");
-
             if (e.Data1 < 0 || e.Data1 > 127)
                 result.AddError($"{prefix}.Data1",
                     $"Data1 MIDI doit être entre 0 et 127 (actuel : {e.Data1}).");

--- a/src/LiveCompanion.EngineMock/MidiEngineMock.cs
+++ b/src/LiveCompanion.EngineMock/MidiEngineMock.cs
@@ -18,7 +18,7 @@ public sealed class MidiEngineMock : IMidiEngine
     private MidiConfig? _config;
 
     private readonly object _lock = new();
-    private readonly List<MidiEvent> _sentEvents = [];
+    private readonly List<MidiSentRecord> _sentEvents = [];
 
     public MidiEngineMock(ILogService log)
     {
@@ -33,7 +33,7 @@ public sealed class MidiEngineMock : IMidiEngine
     /// Copie en lecture seule de tous les événements MIDI envoyés depuis l'initialisation.
     /// Thread-safe.
     /// </summary>
-    public IReadOnlyList<MidiEvent> SentEvents
+    public IReadOnlyList<MidiSentRecord> SentEvents
     {
         get { lock (_lock) return _sentEvents.ToList().AsReadOnly(); }
     }
@@ -56,20 +56,34 @@ public sealed class MidiEngineMock : IMidiEngine
     public IReadOnlyList<string> GetAvailablePorts() => _fakePorts;
 
     /// <inheritdoc/>
-    public Task SendEventAsync(MidiEvent midiEvent)
+    public Task SendEventAsync(MidiEvent midiEvent, IReadOnlyList<MidiProfile> profiles)
     {
         ArgumentNullException.ThrowIfNull(midiEvent);
+        ArgumentNullException.ThrowIfNull(profiles);
         ThrowIfNotInitialized();
 
-        lock (_lock)
-            _sentEvents.Add(midiEvent);
+        foreach (var profileId in midiEvent.ProfileIds)
+        {
+            var profile = profiles.FirstOrDefault(p => p.Id == profileId);
+            if (profile?.DeviceOut is null)
+            {
+                _log.Warn(LogSource.EngineMock,
+                    $"[MidiEngine] Profil {profileId} introuvable ou sans port — événement ignoré.");
+                continue;
+            }
 
-        _log.Debug(LogSource.EngineMock,
-            $"[MidiEngine] Send — type={midiEvent.Type}, " +
-            $"device='{midiEvent.DeviceOut}', ch={midiEvent.Channel}, " +
-            $"data1={midiEvent.Data1}, data2={midiEvent.Data2}, " +
-            $"pos={midiEvent.Position}");
+            SendInternal(midiEvent.Type, profile.DeviceOut, profile.DefaultChannel,
+                midiEvent.Data1, midiEvent.Data2);
+        }
 
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task SendDirectAsync(MidiEventType type, string deviceOut, int channel, int data1, int data2)
+    {
+        ThrowIfNotInitialized();
+        SendInternal(type, deviceOut, channel, data1, data2);
         return Task.CompletedTask;
     }
 
@@ -88,6 +102,19 @@ public sealed class MidiEngineMock : IMidiEngine
     // Helpers
     // ------------------------------------------------------------------ //
 
+    private void SendInternal(MidiEventType type, string deviceOut, int channel, int data1, int data2)
+    {
+        var record = new MidiSentRecord(type, deviceOut, channel, data1, data2);
+
+        lock (_lock)
+            _sentEvents.Add(record);
+
+        _log.Debug(LogSource.EngineMock,
+            $"[MidiEngine] Send — type={type}, " +
+            $"device='{deviceOut}', ch={channel}, " +
+            $"data1={data1}, data2={data2}");
+    }
+
     private void ThrowIfNotInitialized()
     {
         if (!_initialized)
@@ -95,3 +122,8 @@ public sealed class MidiEngineMock : IMidiEngine
                 "MidiEngineMock n'est pas initialisé. Appelez InitializeAsync avant toute opération.");
     }
 }
+
+/// <summary>
+/// Enregistrement d'un message MIDI envoyé (pour les tests et le débogage).
+/// </summary>
+public record MidiSentRecord(MidiEventType Type, string DeviceOut, int Channel, int Data1, int Data2);

--- a/src/LiveCompanion.EngineMock/TimelineSchedulerMock.cs
+++ b/src/LiveCompanion.EngineMock/TimelineSchedulerMock.cs
@@ -35,6 +35,7 @@ public sealed class TimelineSchedulerMock : ITimelineScheduler, IDisposable
 
     private readonly IAudioEngine? _audioEngine;
     private readonly IMidiEngine? _midiEngine;
+    private readonly IProjectStore? _projectStore;
 
     private Song? _song;
     private int _sectionIndex;
@@ -61,12 +62,14 @@ public sealed class TimelineSchedulerMock : ITimelineScheduler, IDisposable
         ILogService log,
         Func<bool>? hasActiveVoices = null,
         IAudioEngine? audioEngine = null,
-        IMidiEngine? midiEngine = null)
+        IMidiEngine? midiEngine = null,
+        IProjectStore? projectStore = null)
     {
         _log = log ?? throw new ArgumentNullException(nameof(log));
         _hasActiveVoices = hasActiveVoices ?? (() => false);
         _audioEngine = audioEngine;
         _midiEngine = midiEngine;
+        _projectStore = projectStore;
         _timer = new Timer { AutoReset = false }; // intervalle recalculé à chaque tick
         _timer.Elapsed += OnTimerElapsed;
     }
@@ -347,6 +350,7 @@ public sealed class TimelineSchedulerMock : ITimelineScheduler, IDisposable
         }
 
         // MidiEvents
+        var profiles = _projectStore?.GetSettings().MidiProfiles ?? [];
         foreach (var evt in song.MidiEvents)
         {
             if (evt.Position.SectionIndex != pos.SectionIndex ||
@@ -356,9 +360,10 @@ public sealed class TimelineSchedulerMock : ITimelineScheduler, IDisposable
 
             try
             {
-                _ = _midiEngine?.SendEventAsync(evt);
+                _ = _midiEngine?.SendEventAsync(evt, profiles);
                 _log.Debug(LogSource.EngineMock,
-                    $"[Scheduler] Trigger MidiEvent {evt.Type} ch.{evt.Channel} " +
+                    $"[Scheduler] Trigger MidiEvent {evt.Type} " +
+                    $"profiles=[{string.Join(",", evt.ProfileIds)}] " +
                     $"at {pos.SectionIndex}:{pos.Bar}:{pos.Beat}");
             }
             catch (InvalidOperationException ex)

--- a/src/LiveCompanion.EngineReal/MidiEngineReal.cs
+++ b/src/LiveCompanion.EngineReal/MidiEngineReal.cs
@@ -115,29 +115,34 @@ public sealed class MidiEngineReal : IMidiEngine, IDisposable
     }
 
     /// <inheritdoc/>
-    public Task SendEventAsync(MidiEvent midiEvent)
+    public Task SendEventAsync(MidiEvent midiEvent, IReadOnlyList<MidiProfile> profiles)
     {
         ArgumentNullException.ThrowIfNull(midiEvent);
+        ArgumentNullException.ThrowIfNull(profiles);
         ThrowIfNotInitialized();
 
-        lock (_lock)
+        foreach (var profileId in midiEvent.ProfileIds)
         {
-            if (!_openPorts.TryGetValue(midiEvent.DeviceOut, out var midiOut))
+            var profile = profiles.FirstOrDefault(p => p.Id == profileId);
+            if (profile?.DeviceOut is null)
             {
                 _log.Warn(LogSource.EngineReal,
-                    $"[MidiEngine] Device '{midiEvent.DeviceOut}' non ouvert — événement ignoré.");
-                return Task.CompletedTask;
+                    $"[MidiEngine] Profil {profileId} introuvable ou sans port — événement ignoré.");
+                continue;
             }
 
-            int message = BuildMidiMessage(midiEvent);
-            midiOut.Send(message);
+            SendToPort(midiEvent.Type, profile.DeviceOut, profile.DefaultChannel,
+                midiEvent.Data1, midiEvent.Data2);
         }
 
-        _log.Debug(LogSource.EngineReal,
-            $"[MidiEngine] Send — type={midiEvent.Type}, " +
-            $"device='{midiEvent.DeviceOut}', ch={midiEvent.Channel}, " +
-            $"data1={midiEvent.Data1}, data2={midiEvent.Data2}");
+        return Task.CompletedTask;
+    }
 
+    /// <inheritdoc/>
+    public Task SendDirectAsync(MidiEventType type, string deviceOut, int channel, int data1, int data2)
+    {
+        ThrowIfNotInitialized();
+        SendToPort(type, deviceOut, channel, data1, data2);
         return Task.CompletedTask;
     }
 
@@ -165,34 +170,55 @@ public sealed class MidiEngineReal : IMidiEngine, IDisposable
     }
 
     // ------------------------------------------------------------------ //
-    // MIDI message building
+    // MIDI message building & sending
     // ------------------------------------------------------------------ //
+
+    private void SendToPort(MidiEventType type, string deviceOut, int channel, int data1, int data2)
+    {
+        lock (_lock)
+        {
+            if (!_openPorts.TryGetValue(deviceOut, out var midiOut))
+            {
+                _log.Warn(LogSource.EngineReal,
+                    $"[MidiEngine] Device '{deviceOut}' non ouvert — événement ignoré.");
+                return;
+            }
+
+            int message = BuildMidiMessage(type, channel, data1, data2);
+            midiOut.Send(message);
+        }
+
+        _log.Debug(LogSource.EngineReal,
+            $"[MidiEngine] Send — type={type}, " +
+            $"device='{deviceOut}', ch={channel}, " +
+            $"data1={data1}, data2={data2}");
+    }
 
     /// <summary>
     /// Construit le message MIDI 32 bits (short message) attendu par <see cref="MidiOut.Send"/>.
     /// Format : status | (data1 &lt;&lt; 8) | (data2 &lt;&lt; 16).
     /// </summary>
-    internal static int BuildMidiMessage(MidiEvent evt)
+    internal static int BuildMidiMessage(MidiEventType type, int channel, int data1, int data2)
     {
-        int channel = Math.Clamp(evt.Channel, 1, 16) - 1; // 0-based
-        int data1 = Math.Clamp(evt.Data1, 0, 127);
-        int data2 = Math.Clamp(evt.Data2, 0, 127);
+        int ch = Math.Clamp(channel, 1, 16) - 1; // 0-based
+        int d1 = Math.Clamp(data1, 0, 127);
+        int d2 = Math.Clamp(data2, 0, 127);
 
-        int status = evt.Type switch
+        int status = type switch
         {
-            MidiEventType.NoteOn => 0x90 | channel,
-            MidiEventType.NoteOff => 0x80 | channel,
-            MidiEventType.ControlChange => 0xB0 | channel,
-            MidiEventType.ProgramChange => 0xC0 | channel,
-            _ => throw new ArgumentOutOfRangeException(nameof(evt),
-                $"Type MIDI non supporté : {evt.Type}"),
+            MidiEventType.NoteOn => 0x90 | ch,
+            MidiEventType.NoteOff => 0x80 | ch,
+            MidiEventType.ControlChange => 0xB0 | ch,
+            MidiEventType.ProgramChange => 0xC0 | ch,
+            _ => throw new ArgumentOutOfRangeException(nameof(type),
+                $"Type MIDI non supporté : {type}"),
         };
 
         // ProgramChange n'a qu'un seul octet de données
-        if (evt.Type == MidiEventType.ProgramChange)
-            return status | (data1 << 8);
+        if (type == MidiEventType.ProgramChange)
+            return status | (d1 << 8);
 
-        return status | (data1 << 8) | (data2 << 16);
+        return status | (d1 << 8) | (d2 << 16);
     }
 
     // ------------------------------------------------------------------ //

--- a/src/LiveCompanion.EngineReal/TimelineSchedulerReal.cs
+++ b/src/LiveCompanion.EngineReal/TimelineSchedulerReal.cs
@@ -26,6 +26,7 @@ public sealed class TimelineSchedulerReal : ITimelineScheduler, IDisposable
     private readonly Func<bool> _hasActiveVoices;
     private readonly IAudioEngine? _audioEngine;
     private readonly IMidiEngine? _midiEngine;
+    private readonly IProjectStore? _projectStore;
 
     // ------------------------------------------------------------------ //
     // State
@@ -52,12 +53,14 @@ public sealed class TimelineSchedulerReal : ITimelineScheduler, IDisposable
         ILogService log,
         Func<bool>? hasActiveVoices = null,
         IAudioEngine? audioEngine = null,
-        IMidiEngine? midiEngine = null)
+        IMidiEngine? midiEngine = null,
+        IProjectStore? projectStore = null)
     {
         _log = log ?? throw new ArgumentNullException(nameof(log));
         _hasActiveVoices = hasActiveVoices ?? (() => false);
         _audioEngine = audioEngine;
         _midiEngine = midiEngine;
+        _projectStore = projectStore;
     }
 
     // ------------------------------------------------------------------ //
@@ -432,6 +435,7 @@ public sealed class TimelineSchedulerReal : ITimelineScheduler, IDisposable
 
     private void TriggerMidiAtPosition(Song song, TimelinePosition pos)
     {
+        var profiles = _projectStore?.GetSettings().MidiProfiles ?? [];
         foreach (var evt in song.MidiEvents)
         {
             if (evt.Position.SectionIndex != pos.SectionIndex ||
@@ -441,9 +445,10 @@ public sealed class TimelineSchedulerReal : ITimelineScheduler, IDisposable
 
             try
             {
-                _ = _midiEngine?.SendEventAsync(evt);
+                _ = _midiEngine?.SendEventAsync(evt, profiles);
                 _log.Debug(LogSource.EngineReal,
-                    $"[Scheduler] Trigger MidiEvent {evt.Type} ch.{evt.Channel} at {pos}");
+                    $"[Scheduler] Trigger MidiEvent {evt.Type} " +
+                    $"profiles=[{string.Join(",", evt.ProfileIds)}] at {pos}");
             }
             catch (Exception ex)
             {

--- a/src/LiveCompanion.UI/ServiceCollectionExtensions.cs
+++ b/src/LiveCompanion.UI/ServiceCollectionExtensions.cs
@@ -112,11 +112,13 @@ public static class ServiceCollectionExtensions
             var audioMock = sp.GetRequiredService<AudioEngineMock>();
             var audioEngine = sp.GetRequiredService<IAudioEngine>();
             var midiEngine = sp.GetRequiredService<IMidiEngine>();
+            var projectStore = sp.GetRequiredService<IProjectStore>();
             return new TimelineSchedulerMock(
                 log,
                 () => audioMock.ActiveVoices > 0,
                 audioEngine,
-                midiEngine);
+                midiEngine,
+                projectStore);
         });
 
         return services;
@@ -164,11 +166,13 @@ public static class ServiceCollectionExtensions
             var audioReal = sp.GetRequiredService<AudioEngineReal>();
             var audioEngine = sp.GetRequiredService<IAudioEngine>();
             var midiEngine = sp.GetRequiredService<IMidiEngine>();
+            var projectStore = sp.GetRequiredService<IProjectStore>();
             return new TimelineSchedulerReal(
                 log,
                 () => audioReal.ActiveVoices > 0,
                 audioEngine,
-                midiEngine);
+                midiEngine,
+                projectStore);
         });
 
         return services;

--- a/src/LiveCompanion.UI/ViewModels/ConfigViewModel.cs
+++ b/src/LiveCompanion.UI/ViewModels/ConfigViewModel.cs
@@ -62,6 +62,40 @@ public partial class ConfigViewModel : ViewModelBase
     public int SelectedMidiPortCount => AvailableMidiPorts.Count(p => p.IsSelected);
 
     // ------------------------------------------------------------------ //
+    // Profils MIDI — Propriétés observables
+    // ------------------------------------------------------------------ //
+
+    /// <summary>Profils MIDI (un profil = un appareil avec ses raccourcis).</summary>
+    public ObservableCollection<MidiProfile> MidiProfiles { get; } = [];
+
+    [ObservableProperty]
+    private MidiProfile? _selectedMidiProfile;
+
+    /// <summary>Raccourcis du profil sélectionné.</summary>
+    public ObservableCollection<MidiPreset> CurrentProfilePresets { get; } = [];
+
+    [ObservableProperty]
+    private MidiPreset? _selectedPreset;
+
+    /// <summary>Types d'événements MIDI pour le ComboBox d'ajout de raccourci.</summary>
+    public IReadOnlyList<MidiEventType> AvailableMidiEventTypes { get; } = Enum.GetValues<MidiEventType>();
+
+    [ObservableProperty]
+    private string _newPresetName = string.Empty;
+
+    [ObservableProperty]
+    private MidiEventType _newPresetType = MidiEventType.ControlChange;
+
+    [ObservableProperty]
+    private int _newPresetData1;
+
+    [ObservableProperty]
+    private int _newPresetData2;
+
+    [ObservableProperty]
+    private string? _profileStatusMessage;
+
+    // ------------------------------------------------------------------ //
     // Constructeur
     // ------------------------------------------------------------------ //
 
@@ -98,8 +132,23 @@ public partial class ConfigViewModel : ViewModelBase
             AvailableMidiPorts.Add(item);
         }
 
+        // Charger les profils MIDI
+        foreach (var profile in _store.GetSettings().MidiProfiles)
+            MidiProfiles.Add(profile);
+
         // Restaurer la configuration sauvegardée
         RestoreSavedSettings();
+    }
+
+    partial void OnSelectedMidiProfileChanged(MidiProfile? value)
+    {
+        CurrentProfilePresets.Clear();
+        SelectedPreset = null;
+
+        if (value is null) return;
+
+        foreach (var preset in value.Presets)
+            CurrentProfilePresets.Add(preset);
     }
 
     // ------------------------------------------------------------------ //
@@ -281,6 +330,95 @@ public partial class ConfigViewModel : ViewModelBase
         {
             MidiStatusMessage = "Maximum 6 ports MIDI.";
         }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Profils MIDI — Commandes
+    // ------------------------------------------------------------------ //
+
+    [RelayCommand]
+    private void AddMidiProfile()
+    {
+        var profile = new MidiProfile { Name = $"Profil {MidiProfiles.Count + 1}" };
+        MidiProfiles.Add(profile);
+        SelectedMidiProfile = profile;
+        PersistProfiles();
+        ProfileStatusMessage = $"Profil \"{profile.Name}\" créé.";
+    }
+
+    [RelayCommand]
+    private void DeleteMidiProfile()
+    {
+        if (SelectedMidiProfile is null) return;
+
+        var name = SelectedMidiProfile.Name;
+        MidiProfiles.Remove(SelectedMidiProfile);
+        SelectedMidiProfile = MidiProfiles.FirstOrDefault();
+        PersistProfiles();
+        ProfileStatusMessage = $"Profil \"{name}\" supprimé.";
+    }
+
+    [RelayCommand]
+    private void RenameMidiProfile(string newName)
+    {
+        if (SelectedMidiProfile is null || string.IsNullOrWhiteSpace(newName)) return;
+
+        SelectedMidiProfile.Name = newName.Trim();
+        // Force UI refresh — replace in collection
+        var index = MidiProfiles.IndexOf(SelectedMidiProfile);
+        if (index >= 0)
+        {
+            var profile = SelectedMidiProfile;
+            MidiProfiles[index] = profile;
+            SelectedMidiProfile = profile;
+        }
+        PersistProfiles();
+    }
+
+    [RelayCommand]
+    private void AddPresetToProfile()
+    {
+        if (SelectedMidiProfile is null) return;
+
+        var preset = new MidiPreset
+        {
+            Name = string.IsNullOrWhiteSpace(NewPresetName) ? $"Raccourci {CurrentProfilePresets.Count + 1}" : NewPresetName.Trim(),
+            Type = NewPresetType,
+            Data1 = NewPresetData1,
+            Data2 = NewPresetData2,
+        };
+
+        SelectedMidiProfile.Presets.Add(preset);
+        CurrentProfilePresets.Add(preset);
+        SelectedPreset = preset;
+
+        // Reset form
+        NewPresetName = string.Empty;
+        NewPresetData1 = 0;
+        NewPresetData2 = 0;
+
+        PersistProfiles();
+        ProfileStatusMessage = $"Raccourci \"{preset.Name}\" ajouté.";
+    }
+
+    [RelayCommand]
+    private void DeletePresetFromProfile()
+    {
+        if (SelectedMidiProfile is null || SelectedPreset is null) return;
+
+        var name = SelectedPreset.Name;
+        SelectedMidiProfile.Presets.Remove(SelectedPreset);
+        CurrentProfilePresets.Remove(SelectedPreset);
+        SelectedPreset = CurrentProfilePresets.LastOrDefault();
+        PersistProfiles();
+        ProfileStatusMessage = $"Raccourci \"{name}\" supprimé.";
+    }
+
+    private void PersistProfiles()
+    {
+        var settings = _store.GetSettings();
+        settings.MidiProfiles = MidiProfiles.ToList();
+        _store.SaveSettings(settings);
     }
 }
 

--- a/src/LiveCompanion.UI/ViewModels/ConfigViewModel.cs
+++ b/src/LiveCompanion.UI/ViewModels/ConfigViewModel.cs
@@ -154,6 +154,17 @@ public partial class ConfigViewModel : ViewModelBase
             CurrentProfilePresets.Add(preset);
     }
 
+    partial void OnSelectedPresetChanged(MidiPreset? value)
+    {
+        if (value is null) return;
+
+        // Pré-remplir le formulaire avec les valeurs du preset sélectionné
+        NewPresetName = value.Name;
+        NewPresetType = value.Type;
+        NewPresetData1 = value.Data1;
+        NewPresetData2 = value.Data2;
+    }
+
     // ------------------------------------------------------------------ //
     // Restauration de la configuration sauvegardée
     // ------------------------------------------------------------------ //
@@ -393,6 +404,31 @@ public partial class ConfigViewModel : ViewModelBase
 
         PersistProfiles();
         ProfileStatusMessage = $"Raccourci \"{preset.Name}\" ajouté.";
+    }
+
+    [RelayCommand]
+    private void UpdateSelectedPreset()
+    {
+        if (SelectedMidiProfile is null || SelectedPreset is null) return;
+
+        SelectedPreset.Name = string.IsNullOrWhiteSpace(NewPresetName)
+            ? SelectedPreset.Name
+            : NewPresetName.Trim();
+        SelectedPreset.Type = NewPresetType;
+        SelectedPreset.Data1 = NewPresetData1;
+        SelectedPreset.Data2 = NewPresetData2;
+
+        // Refresh dans la liste observable pour mettre à jour l'affichage
+        var index = CurrentProfilePresets.IndexOf(SelectedPreset);
+        if (index >= 0)
+        {
+            var preset = SelectedPreset;
+            CurrentProfilePresets[index] = preset;
+            SelectedPreset = preset;
+        }
+
+        PersistProfiles();
+        ProfileStatusMessage = $"Raccourci \"{SelectedPreset.Name}\" modifié.";
     }
 
     [RelayCommand]

--- a/src/LiveCompanion.UI/ViewModels/ConfigViewModel.cs
+++ b/src/LiveCompanion.UI/ViewModels/ConfigViewModel.cs
@@ -303,16 +303,7 @@ public partial class ConfigViewModel : ViewModelBase
         // Envoie un NoteOn de test sur chaque port sélectionné
         foreach (var port in selectedPorts)
         {
-            var testEvent = new MidiEvent
-            {
-                Type = MidiEventType.NoteOn,
-                DeviceOut = port,
-                Channel = 1,
-                Data1 = 60, // C4
-                Data2 = 100,
-                Position = new TimelinePosition(0, 1, 1, 0)
-            };
-            await _midiEngine.SendEventAsync(testEvent);
+            await _midiEngine.SendDirectAsync(MidiEventType.NoteOn, port, 1, 60, 100);
         }
 
         MidiTestResult = $"Test envoyé sur {selectedPorts.Count} port(s) — NoteOn C4";

--- a/src/LiveCompanion.UI/ViewModels/ConfigViewModel.cs
+++ b/src/LiveCompanion.UI/ViewModels/ConfigViewModel.cs
@@ -77,6 +77,9 @@ public partial class ConfigViewModel : ViewModelBase
     [ObservableProperty]
     private MidiPreset? _selectedPreset;
 
+    /// <summary>Noms des ports MIDI disponibles pour l'association au profil.</summary>
+    public IReadOnlyList<string> AvailableMidiPortNames => _midiEngine.GetAvailablePorts();
+
     /// <summary>Types d'événements MIDI pour le ComboBox d'ajout de raccourci.</summary>
     public IReadOnlyList<MidiEventType> AvailableMidiEventTypes { get; } = Enum.GetValues<MidiEventType>();
 

--- a/src/LiveCompanion.UI/ViewModels/EditorViewModel.cs
+++ b/src/LiveCompanion.UI/ViewModels/EditorViewModel.cs
@@ -72,9 +72,6 @@ public partial class EditorViewModel : ViewModelBase
     /// <summary>Types d'événements MIDI pour le ComboBox.</summary>
     public IReadOnlyList<MidiEventType> AvailableMidiEventTypes { get; } = Enum.GetValues<MidiEventType>();
 
-    /// <summary>Ports MIDI de sortie disponibles (mock).</summary>
-    public IReadOnlyList<string> AvailableMidiPorts => _midiEngine.GetAvailablePorts();
-
     // ------------------------------------------------------------------ //
     // Profils MIDI (raccourcis par appareil)
     // ------------------------------------------------------------------ //
@@ -154,6 +151,11 @@ public partial class EditorViewModel : ViewModelBase
         // Tenter de re-sélectionner le même profil
         if (previousProfileId is not null)
             SelectedMidiProfile = MidiProfiles.FirstOrDefault(p => p.Id == previousProfileId);
+
+        // Propager les profils mis à jour aux VMs d'événements MIDI existants
+        var profiles = MidiProfiles.ToList();
+        foreach (var evtVm in MidiEvents)
+            evtVm.RefreshProfiles(profiles);
     }
 
     private void RefreshSongList()
@@ -203,8 +205,9 @@ public partial class EditorViewModel : ViewModelBase
             SelectedAudioClip = AudioClips[0];
 
         // MIDI
+        var profiles = MidiProfiles.ToList();
         foreach (var evt in song.MidiEvents)
-            MidiEvents.Add(new MidiEventViewModel(evt));
+            MidiEvents.Add(new MidiEventViewModel(evt, profiles));
 
         if (MidiEvents.Count > 0)
             SelectedMidiEvent = MidiEvents[0];
@@ -427,13 +430,11 @@ public partial class EditorViewModel : ViewModelBase
         var evt = new MidiEvent
         {
             Type = MidiEventType.ProgramChange,
-            DeviceOut = AvailableMidiPorts.FirstOrDefault() ?? string.Empty,
-            Channel = 1,
             Position = TimelinePosition.Zero,
         };
 
         SelectedSong.MidiEvents.Add(evt);
-        var vm = new MidiEventViewModel(evt);
+        var vm = new MidiEventViewModel(evt, MidiProfiles.ToList());
         MidiEvents.Add(vm);
         SelectedMidiEvent = vm;
     }
@@ -464,7 +465,7 @@ public partial class EditorViewModel : ViewModelBase
 
         try
         {
-            await _midiEngine.SendEventAsync(SelectedMidiEvent.Model);
+            await _midiEngine.SendEventAsync(SelectedMidiEvent.Model, MidiProfiles.ToList());
             _log.Debug(LogSource.UI, $"[EditorVM] Test MIDI → {SelectedMidiEvent.DisplaySummary}");
             StatusMessage = $"Test MIDI envoyé : {SelectedMidiEvent.DisplaySummary}";
         }
@@ -487,13 +488,13 @@ public partial class EditorViewModel : ViewModelBase
         SelectedMidiEvent.Data1 = SelectedMidiPreset.Data1;
         SelectedMidiEvent.Data2 = SelectedMidiPreset.Data2;
 
-        // Pré-remplir port et canal depuis le profil
+        // Cocher automatiquement le profil source du raccourci
         if (SelectedMidiProfile is not null)
         {
-            if (!string.IsNullOrEmpty(SelectedMidiProfile.DeviceOut))
-                SelectedMidiEvent.DeviceOut = SelectedMidiProfile.DeviceOut;
-
-            SelectedMidiEvent.Channel = SelectedMidiProfile.DefaultChannel;
+            var profileItem = SelectedMidiEvent.ProfileSelections
+                .FirstOrDefault(p => p.Profile.Id == SelectedMidiProfile.Id);
+            if (profileItem is not null)
+                profileItem.IsSelected = true;
         }
 
         StatusMessage = $"Raccourci \"{SelectedMidiPreset.Name}\" appliqué.";

--- a/src/LiveCompanion.UI/ViewModels/EditorViewModel.cs
+++ b/src/LiveCompanion.UI/ViewModels/EditorViewModel.cs
@@ -76,10 +76,16 @@ public partial class EditorViewModel : ViewModelBase
     public IReadOnlyList<string> AvailableMidiPorts => _midiEngine.GetAvailablePorts();
 
     // ------------------------------------------------------------------ //
-    // Presets MIDI (#raccourcis)
+    // Profils MIDI (raccourcis par appareil)
     // ------------------------------------------------------------------ //
 
-    public ObservableCollection<MidiPreset> MidiPresets { get; } = [];
+    public ObservableCollection<MidiProfile> MidiProfiles { get; } = [];
+
+    [ObservableProperty]
+    private MidiProfile? _selectedMidiProfile;
+
+    /// <summary>Raccourcis du profil sélectionné.</summary>
+    public ObservableCollection<MidiPreset> AvailablePresets { get; } = [];
 
     [ObservableProperty]
     private MidiPreset? _selectedMidiPreset;
@@ -113,13 +119,41 @@ public partial class EditorViewModel : ViewModelBase
         _log = log;
         _liveModeGuard = liveModeGuard;
         RefreshSongList();
-        LoadMidiPresets();
+        LoadMidiProfiles();
     }
 
-    private void LoadMidiPresets()
+    private void LoadMidiProfiles()
     {
-        foreach (var preset in _projectStore.GetSettings().MidiPresets)
-            MidiPresets.Add(preset);
+        MidiProfiles.Clear();
+        foreach (var profile in _projectStore.GetSettings().MidiProfiles)
+            MidiProfiles.Add(profile);
+
+        if (MidiProfiles.Count > 0)
+            SelectedMidiProfile = MidiProfiles[0];
+    }
+
+    partial void OnSelectedMidiProfileChanged(MidiProfile? value)
+    {
+        AvailablePresets.Clear();
+        SelectedMidiPreset = null;
+
+        if (value is null) return;
+
+        foreach (var preset in value.Presets)
+            AvailablePresets.Add(preset);
+    }
+
+    /// <summary>
+    /// Recharge les profils MIDI depuis les settings (appelé quand on revient de Config).
+    /// </summary>
+    public void RefreshMidiProfiles()
+    {
+        var previousProfileId = SelectedMidiProfile?.Id;
+        LoadMidiProfiles();
+
+        // Tenter de re-sélectionner le même profil
+        if (previousProfileId is not null)
+            SelectedMidiProfile = MidiProfiles.FirstOrDefault(p => p.Id == previousProfileId);
     }
 
     private void RefreshSongList()
@@ -441,7 +475,7 @@ public partial class EditorViewModel : ViewModelBase
     }
 
     // ------------------------------------------------------------------ //
-    // Commandes — Presets MIDI
+    // Commandes — Raccourcis MIDI (depuis profils)
     // ------------------------------------------------------------------ //
 
     [RelayCommand]
@@ -450,51 +484,9 @@ public partial class EditorViewModel : ViewModelBase
         if (SelectedMidiEvent is null || SelectedMidiPreset is null) return;
 
         SelectedMidiEvent.Type = SelectedMidiPreset.Type;
-        SelectedMidiEvent.Channel = SelectedMidiPreset.Channel;
         SelectedMidiEvent.Data1 = SelectedMidiPreset.Data1;
         SelectedMidiEvent.Data2 = SelectedMidiPreset.Data2;
-        StatusMessage = $"Preset \"{SelectedMidiPreset.Name}\" appliqué.";
-    }
-
-    [RelayCommand]
-    private void SaveMidiEventAsPreset()
-    {
-        if (SelectedMidiEvent is null) return;
-
-        SelectedMidiEvent.ApplyToModel();
-
-        var preset = new MidiPreset
-        {
-            Name = $"Preset {MidiPresets.Count + 1}",
-            Type = SelectedMidiEvent.Type,
-            Channel = SelectedMidiEvent.Channel,
-            Data1 = SelectedMidiEvent.Data1,
-            Data2 = SelectedMidiEvent.Data2,
-        };
-
-        MidiPresets.Add(preset);
-        SelectedMidiPreset = preset;
-        PersistPresets();
-        StatusMessage = $"Preset \"{preset.Name}\" créé.";
-    }
-
-    [RelayCommand]
-    private void DeleteMidiPreset()
-    {
-        if (SelectedMidiPreset is null) return;
-
-        var name = SelectedMidiPreset.Name;
-        MidiPresets.Remove(SelectedMidiPreset);
-        SelectedMidiPreset = null;
-        PersistPresets();
-        StatusMessage = $"Preset \"{name}\" supprimé.";
-    }
-
-    private void PersistPresets()
-    {
-        var settings = _projectStore.GetSettings();
-        settings.MidiPresets = MidiPresets.ToList();
-        _projectStore.SaveSettings(settings);
+        StatusMessage = $"Raccourci \"{SelectedMidiPreset.Name}\" appliqué.";
     }
 
     // ------------------------------------------------------------------ //

--- a/src/LiveCompanion.UI/ViewModels/EditorViewModel.cs
+++ b/src/LiveCompanion.UI/ViewModels/EditorViewModel.cs
@@ -487,9 +487,14 @@ public partial class EditorViewModel : ViewModelBase
         SelectedMidiEvent.Data1 = SelectedMidiPreset.Data1;
         SelectedMidiEvent.Data2 = SelectedMidiPreset.Data2;
 
-        // Pré-remplir le port MIDI si le profil en a un
-        if (!string.IsNullOrEmpty(SelectedMidiProfile?.DeviceOut))
-            SelectedMidiEvent.DeviceOut = SelectedMidiProfile.DeviceOut;
+        // Pré-remplir port et canal depuis le profil
+        if (SelectedMidiProfile is not null)
+        {
+            if (!string.IsNullOrEmpty(SelectedMidiProfile.DeviceOut))
+                SelectedMidiEvent.DeviceOut = SelectedMidiProfile.DeviceOut;
+
+            SelectedMidiEvent.Channel = SelectedMidiProfile.DefaultChannel;
+        }
 
         StatusMessage = $"Raccourci \"{SelectedMidiPreset.Name}\" appliqué.";
     }

--- a/src/LiveCompanion.UI/ViewModels/EditorViewModel.cs
+++ b/src/LiveCompanion.UI/ViewModels/EditorViewModel.cs
@@ -76,6 +76,15 @@ public partial class EditorViewModel : ViewModelBase
     public IReadOnlyList<string> AvailableMidiPorts => _midiEngine.GetAvailablePorts();
 
     // ------------------------------------------------------------------ //
+    // Presets MIDI (#raccourcis)
+    // ------------------------------------------------------------------ //
+
+    public ObservableCollection<MidiPreset> MidiPresets { get; } = [];
+
+    [ObservableProperty]
+    private MidiPreset? _selectedMidiPreset;
+
+    // ------------------------------------------------------------------ //
     // Piste de clic (#20)
     // ------------------------------------------------------------------ //
 
@@ -104,6 +113,13 @@ public partial class EditorViewModel : ViewModelBase
         _log = log;
         _liveModeGuard = liveModeGuard;
         RefreshSongList();
+        LoadMidiPresets();
+    }
+
+    private void LoadMidiPresets()
+    {
+        foreach (var preset in _projectStore.GetSettings().MidiPresets)
+            MidiPresets.Add(preset);
     }
 
     private void RefreshSongList()
@@ -422,6 +438,63 @@ public partial class EditorViewModel : ViewModelBase
         {
             StatusMessage = "Initialisez le MIDI dans Configuration avant de tester.";
         }
+    }
+
+    // ------------------------------------------------------------------ //
+    // Commandes — Presets MIDI
+    // ------------------------------------------------------------------ //
+
+    [RelayCommand]
+    private void ApplyMidiPreset()
+    {
+        if (SelectedMidiEvent is null || SelectedMidiPreset is null) return;
+
+        SelectedMidiEvent.Type = SelectedMidiPreset.Type;
+        SelectedMidiEvent.Channel = SelectedMidiPreset.Channel;
+        SelectedMidiEvent.Data1 = SelectedMidiPreset.Data1;
+        SelectedMidiEvent.Data2 = SelectedMidiPreset.Data2;
+        StatusMessage = $"Preset \"{SelectedMidiPreset.Name}\" appliqué.";
+    }
+
+    [RelayCommand]
+    private void SaveMidiEventAsPreset()
+    {
+        if (SelectedMidiEvent is null) return;
+
+        SelectedMidiEvent.ApplyToModel();
+
+        var preset = new MidiPreset
+        {
+            Name = $"Preset {MidiPresets.Count + 1}",
+            Type = SelectedMidiEvent.Type,
+            Channel = SelectedMidiEvent.Channel,
+            Data1 = SelectedMidiEvent.Data1,
+            Data2 = SelectedMidiEvent.Data2,
+        };
+
+        MidiPresets.Add(preset);
+        SelectedMidiPreset = preset;
+        PersistPresets();
+        StatusMessage = $"Preset \"{preset.Name}\" créé.";
+    }
+
+    [RelayCommand]
+    private void DeleteMidiPreset()
+    {
+        if (SelectedMidiPreset is null) return;
+
+        var name = SelectedMidiPreset.Name;
+        MidiPresets.Remove(SelectedMidiPreset);
+        SelectedMidiPreset = null;
+        PersistPresets();
+        StatusMessage = $"Preset \"{name}\" supprimé.";
+    }
+
+    private void PersistPresets()
+    {
+        var settings = _projectStore.GetSettings();
+        settings.MidiPresets = MidiPresets.ToList();
+        _projectStore.SaveSettings(settings);
     }
 
     // ------------------------------------------------------------------ //

--- a/src/LiveCompanion.UI/ViewModels/EditorViewModel.cs
+++ b/src/LiveCompanion.UI/ViewModels/EditorViewModel.cs
@@ -486,6 +486,11 @@ public partial class EditorViewModel : ViewModelBase
         SelectedMidiEvent.Type = SelectedMidiPreset.Type;
         SelectedMidiEvent.Data1 = SelectedMidiPreset.Data1;
         SelectedMidiEvent.Data2 = SelectedMidiPreset.Data2;
+
+        // Pré-remplir le port MIDI si le profil en a un
+        if (!string.IsNullOrEmpty(SelectedMidiProfile?.DeviceOut))
+            SelectedMidiEvent.DeviceOut = SelectedMidiProfile.DeviceOut;
+
         StatusMessage = $"Raccourci \"{SelectedMidiPreset.Name}\" appliqué.";
     }
 

--- a/src/LiveCompanion.UI/ViewModels/MidiEventViewModel.cs
+++ b/src/LiveCompanion.UI/ViewModels/MidiEventViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -13,18 +14,31 @@ public partial class MidiEventViewModel : ObservableValidator
 {
     private readonly MidiEvent _model;
 
-    public MidiEventViewModel(MidiEvent model)
+    public MidiEventViewModel(MidiEvent model, IReadOnlyList<MidiProfile> availableProfiles)
     {
         _model = model;
         _type = model.Type;
-        _deviceOut = model.DeviceOut;
-        _channel = model.Channel;
         _data1 = model.Data1;
         _data2 = model.Data2;
         _sectionIndex = model.Position.SectionIndex;
         _bar = model.Position.Bar;
         _beat = model.Position.Beat;
         _tick = model.Position.Tick;
+
+        // Construire la liste de sélection des profils
+        foreach (var profile in availableProfiles)
+        {
+            var item = new ProfileSelectionItem(profile)
+            {
+                IsSelected = model.ProfileIds.Contains(profile.Id)
+            };
+            item.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(ProfileSelectionItem.IsSelected))
+                    OnPropertyChanged(nameof(DisplaySummary));
+            };
+            ProfileSelections.Add(item);
+        }
     }
 
     public Guid Id => _model.Id;
@@ -32,15 +46,8 @@ public partial class MidiEventViewModel : ObservableValidator
     [ObservableProperty]
     private MidiEventType _type;
 
-    [ObservableProperty]
-    [NotifyDataErrorInfo]
-    [Required(ErrorMessage = "Le device de sortie est requis.")]
-    private string _deviceOut;
-
-    [ObservableProperty]
-    [NotifyDataErrorInfo]
-    [Range(1, 16, ErrorMessage = "Le canal MIDI doit être entre 1 et 16.")]
-    private int _channel;
+    /// <summary>Sélection des profils (multi-select via CheckBox).</summary>
+    public ObservableCollection<ProfileSelectionItem> ProfileSelections { get; } = [];
 
     [ObservableProperty]
     [NotifyDataErrorInfo]
@@ -86,8 +93,10 @@ public partial class MidiEventViewModel : ObservableValidator
     public void ApplyToModel()
     {
         _model.Type = Type;
-        _model.DeviceOut = DeviceOut;
-        _model.Channel = Channel;
+        _model.ProfileIds = ProfileSelections
+            .Where(p => p.IsSelected)
+            .Select(p => p.Profile.Id)
+            .ToList();
         _model.Data1 = Data1;
         _model.Data2 = Data2;
         _model.Position = new TimelinePosition(SectionIndex, Bar, Beat, Tick);
@@ -103,5 +112,65 @@ public partial class MidiEventViewModel : ObservableValidator
     public new bool HasErrors => ((INotifyDataErrorInfo)this).HasErrors;
 
     /// <summary>Résumé affiché dans la liste.</summary>
-    public string DisplaySummary => $"{Type} ch.{Channel} → {DeviceOut}";
+    public string DisplaySummary
+    {
+        get
+        {
+            var profileNames = ProfileSelections
+                .Where(p => p.IsSelected)
+                .Select(p => p.Profile.Name);
+            var targets = string.Join(", ", profileNames);
+            return string.IsNullOrEmpty(targets)
+                ? $"{Type} (aucun périphérique)"
+                : $"{Type} → {targets}";
+        }
+    }
+
+    /// <summary>
+    /// Met à jour la liste de profils disponibles (appelé quand les profils changent dans Config).
+    /// </summary>
+    public void RefreshProfiles(IReadOnlyList<MidiProfile> availableProfiles)
+    {
+        // Sauvegarder les IDs actuellement sélectionnés
+        var selectedIds = ProfileSelections
+            .Where(p => p.IsSelected)
+            .Select(p => p.Profile.Id)
+            .ToHashSet();
+
+        ProfileSelections.Clear();
+
+        foreach (var profile in availableProfiles)
+        {
+            var item = new ProfileSelectionItem(profile)
+            {
+                IsSelected = selectedIds.Contains(profile.Id)
+            };
+            item.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(ProfileSelectionItem.IsSelected))
+                    OnPropertyChanged(nameof(DisplaySummary));
+            };
+            ProfileSelections.Add(item);
+        }
+
+        OnPropertyChanged(nameof(DisplaySummary));
+    }
+}
+
+/// <summary>
+/// Représente un profil MIDI avec son état de sélection (coché/décoché).
+/// </summary>
+public partial class ProfileSelectionItem : ObservableObject
+{
+    public MidiProfile Profile { get; }
+
+    [ObservableProperty]
+    private bool _isSelected;
+
+    public ProfileSelectionItem(MidiProfile profile)
+    {
+        Profile = profile;
+    }
+
+    public string DisplayName => Profile.Name;
 }

--- a/src/LiveCompanion.UI/Views/ConfigView.xaml
+++ b/src/LiveCompanion.UI/Views/ConfigView.xaml
@@ -248,6 +248,29 @@
                                   Style="{StaticResource ConfigComboStyle}" />
                     </Grid>
 
+                    <!-- Default channel -->
+                    <Grid Margin="0,4">
+                        <Grid.Style>
+                            <Style TargetType="Grid">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedMidiProfile}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="140" />
+                            <ColumnDefinition Width="80" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Canal (1-16)"
+                                   Style="{StaticResource FieldLabel}" />
+                        <TextBox Grid.Column="1"
+                                 Text="{Binding SelectedMidiProfile.DefaultChannel, UpdateSourceTrigger=LostFocus}"
+                                 Style="{StaticResource EditorTextBoxStyle}" />
+                    </Grid>
+
                     <!-- Preset list for selected profile -->
                     <StackPanel>
                         <StackPanel.Style>

--- a/src/LiveCompanion.UI/Views/ConfigView.xaml
+++ b/src/LiveCompanion.UI/Views/ConfigView.xaml
@@ -163,6 +163,203 @@
                 </StackPanel>
             </Border>
 
+            <!-- ============================================================ -->
+            <!-- MIDI PROFILES SECTION                                          -->
+            <!-- ============================================================ -->
+            <Border Style="{StaticResource CardStyle}">
+                <StackPanel>
+                    <TextBlock Text="PROFILS MIDI"
+                               Style="{StaticResource SectionHeader}" />
+
+                    <TextBlock Text="Créez des profils par appareil avec des raccourcis MIDI prédéfinis."
+                               Foreground="#A6ADC8"
+                               FontSize="13"
+                               Margin="0,0,0,8" />
+
+                    <!-- Profile selection + add/delete -->
+                    <Grid Margin="0,4">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="140" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Profil"
+                                   Style="{StaticResource FieldLabel}" />
+                        <ComboBox Grid.Column="1"
+                                  ItemsSource="{Binding MidiProfiles}"
+                                  SelectedItem="{Binding SelectedMidiProfile}"
+                                  DisplayMemberPath="Name"
+                                  Style="{StaticResource ConfigComboStyle}" />
+                        <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="6,0,0,0">
+                            <Button Content="+ Ajouter"
+                                    Command="{Binding AddMidiProfileCommand}"
+                                    Style="{StaticResource ActionButtonStyle}" />
+                            <Button Content="Supprimer"
+                                    Command="{Binding DeleteMidiProfileCommand}"
+                                    Style="{StaticResource ActionButtonStyle}"
+                                    Foreground="#F38BA8" />
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- Profile name edit -->
+                    <Grid Margin="0,4">
+                        <Grid.Style>
+                            <Style TargetType="Grid">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedMidiProfile}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="140" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Nom"
+                                   Style="{StaticResource FieldLabel}" />
+                        <TextBox Grid.Column="1"
+                                 Text="{Binding SelectedMidiProfile.Name, UpdateSourceTrigger=LostFocus}"
+                                 Style="{StaticResource EditorTextBoxStyle}" />
+                    </Grid>
+
+                    <!-- Preset list for selected profile -->
+                    <StackPanel>
+                        <StackPanel.Style>
+                            <Style TargetType="StackPanel">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedMidiProfile}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </StackPanel.Style>>
+                        <TextBlock Text="Raccourcis"
+                                   Foreground="#A6ADC8"
+                                   FontSize="13"
+                                   FontWeight="SemiBold"
+                                   Margin="0,12,0,6" />
+
+                        <ListBox ItemsSource="{Binding CurrentProfilePresets}"
+                                 SelectedItem="{Binding SelectedPreset}"
+                                 Background="Transparent"
+                                 BorderThickness="0"
+                                 MaxHeight="200">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Foreground="#CDD6F4" FontSize="13">
+                                            <Run Text="{Binding Name}" FontWeight="SemiBold" />
+                                            <Run Text=" — " Foreground="#585B70" />
+                                            <Run Text="{Binding Type}" Foreground="#89B4FA" />
+                                            <Run Text=" D1=" Foreground="#585B70" />
+                                            <Run Text="{Binding Data1}" Foreground="#A6E3A1" />
+                                            <Run Text=" D2=" Foreground="#585B70" />
+                                            <Run Text="{Binding Data2}" Foreground="#A6E3A1" />
+                                        </TextBlock>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                            <ListBox.ItemContainerStyle>
+                                <Style TargetType="ListBoxItem">
+                                    <Setter Property="Foreground" Value="#CDD6F4" />
+                                    <Setter Property="Background" Value="Transparent" />
+                                    <Setter Property="Padding" Value="8,4" />
+                                    <Setter Property="Margin" Value="0,1" />
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="ListBoxItem">
+                                                <Border Background="{TemplateBinding Background}"
+                                                        Padding="{TemplateBinding Padding}"
+                                                        CornerRadius="4">
+                                                    <ContentPresenter />
+                                                </Border>
+                                                <ControlTemplate.Triggers>
+                                                    <Trigger Property="IsSelected" Value="True">
+                                                        <Setter Property="Background" Value="#313244" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter Property="Background" Value="#2A2B3D" />
+                                                    </Trigger>
+                                                </ControlTemplate.Triggers>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Style>
+                            </ListBox.ItemContainerStyle>
+                        </ListBox>
+
+                        <!-- Add preset form -->
+                        <TextBlock Text="Ajouter un raccourci"
+                                   Foreground="#A6ADC8"
+                                   FontSize="13"
+                                   FontWeight="SemiBold"
+                                   Margin="0,12,0,6" />
+
+                        <Grid Margin="0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="140" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="Nom"
+                                       Style="{StaticResource FieldLabel}" />
+                            <TextBox Grid.Column="1"
+                                     Text="{Binding NewPresetName, UpdateSourceTrigger=PropertyChanged}"
+                                     Style="{StaticResource EditorTextBoxStyle}" />
+                        </Grid>
+
+                        <Grid Margin="0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="140" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="Type"
+                                       Style="{StaticResource FieldLabel}" />
+                            <ComboBox Grid.Column="1"
+                                      ItemsSource="{Binding AvailableMidiEventTypes}"
+                                      SelectedItem="{Binding NewPresetType}"
+                                      Style="{StaticResource ConfigComboStyle}" />
+                        </Grid>
+
+                        <Grid Margin="0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="140" />
+                                <ColumnDefinition Width="80" />
+                                <ColumnDefinition Width="20" />
+                                <ColumnDefinition Width="80" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="Data1 / Data2"
+                                       Style="{StaticResource FieldLabel}" />
+                            <TextBox Grid.Column="1"
+                                     Text="{Binding NewPresetData1, UpdateSourceTrigger=PropertyChanged}"
+                                     Style="{StaticResource EditorTextBoxStyle}" />
+                            <TextBox Grid.Column="3"
+                                     Text="{Binding NewPresetData2, UpdateSourceTrigger=PropertyChanged}"
+                                     Style="{StaticResource EditorTextBoxStyle}" />
+                        </Grid>
+
+                        <!-- Preset buttons -->
+                        <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                            <Button Content="+ Ajouter raccourci"
+                                    Command="{Binding AddPresetToProfileCommand}"
+                                    Style="{StaticResource ActionButtonStyle}" />
+                            <Button Content="Suppr. raccourci"
+                                    Command="{Binding DeletePresetFromProfileCommand}"
+                                    Style="{StaticResource ActionButtonStyle}"
+                                    Foreground="#F38BA8" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <!-- Profile status -->
+                    <TextBlock Text="{Binding ProfileStatusMessage}"
+                               Foreground="#A6E3A1"
+                               FontSize="12"
+                               Margin="0,8,0,0" />
+                </StackPanel>
+            </Border>
+
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/src/LiveCompanion.UI/Views/ConfigView.xaml
+++ b/src/LiveCompanion.UI/Views/ConfigView.xaml
@@ -392,6 +392,19 @@
                             <Button Content="+ Ajouter raccourci"
                                     Command="{Binding AddPresetToProfileCommand}"
                                     Style="{StaticResource ActionButtonStyle}" />
+                            <Button Content="Modifier raccourci"
+                                    Command="{Binding UpdateSelectedPresetCommand}">
+                                <Button.Style>
+                                    <Style TargetType="Button" BasedOn="{StaticResource ActionButtonStyle}">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding SelectedPreset}" Value="{x:Null}">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+                            </Button>
                             <Button Content="Suppr. raccourci"
                                     Command="{Binding DeletePresetFromProfileCommand}"
                                     Style="{StaticResource ActionButtonStyle}"

--- a/src/LiveCompanion.UI/Views/ConfigView.xaml
+++ b/src/LiveCompanion.UI/Views/ConfigView.xaml
@@ -212,7 +212,7 @@
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </Grid.Style>>
+                        </Grid.Style>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="140" />
                             <ColumnDefinition Width="*" />
@@ -222,6 +222,30 @@
                         <TextBox Grid.Column="1"
                                  Text="{Binding SelectedMidiProfile.Name, UpdateSourceTrigger=LostFocus}"
                                  Style="{StaticResource EditorTextBoxStyle}" />
+                    </Grid>
+
+                    <!-- Profile port assignment -->
+                    <Grid Margin="0,4">
+                        <Grid.Style>
+                            <Style TargetType="Grid">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding SelectedMidiProfile}" Value="{x:Null}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="140" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Port MIDI"
+                                   Style="{StaticResource FieldLabel}" />
+                        <ComboBox Grid.Column="1"
+                                  ItemsSource="{Binding AvailableMidiPortNames}"
+                                  SelectedItem="{Binding SelectedMidiProfile.DeviceOut}"
+                                  Style="{StaticResource ConfigComboStyle}" />
                     </Grid>
 
                     <!-- Preset list for selected profile -->
@@ -235,7 +259,7 @@
                                     </DataTrigger>
                                 </Style.Triggers>
                             </Style>
-                        </StackPanel.Style>>
+                        </StackPanel.Style>
                         <TextBlock Text="Raccourcis"
                                    Foreground="#A6ADC8"
                                    FontSize="13"

--- a/src/LiveCompanion.UI/Views/ConfigView.xaml
+++ b/src/LiveCompanion.UI/Views/ConfigView.xaml
@@ -393,18 +393,8 @@
                                     Command="{Binding AddPresetToProfileCommand}"
                                     Style="{StaticResource ActionButtonStyle}" />
                             <Button Content="Modifier raccourci"
-                                    Command="{Binding UpdateSelectedPresetCommand}">
-                                <Button.Style>
-                                    <Style TargetType="Button" BasedOn="{StaticResource ActionButtonStyle}">
-                                        <Setter Property="Visibility" Value="Visible" />
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding SelectedPreset}" Value="{x:Null}">
-                                                <Setter Property="Visibility" Value="Collapsed" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Button.Style>
-                            </Button>
+                                    Command="{Binding UpdateSelectedPresetCommand}"
+                                    Style="{StaticResource ActionButtonStyle}" />
                             <Button Content="Suppr. raccourci"
                                     Command="{Binding DeletePresetFromProfileCommand}"
                                     Style="{StaticResource ActionButtonStyle}"

--- a/src/LiveCompanion.UI/Views/EditorView.xaml
+++ b/src/LiveCompanion.UI/Views/EditorView.xaml
@@ -549,23 +549,19 @@
                                                   MinWidth="160"
                                                   Margin="0,0,0,12" />
 
-                                        <!-- Device Out -->
-                                        <TextBlock Text="DEVICE MIDI OUT" Style="{StaticResource SectionHeader}" />
-                                        <ComboBox ItemsSource="{Binding DataContext.AvailableMidiPorts,
-                                                      RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                  SelectedItem="{Binding DeviceOut}"
-                                                  Style="{StaticResource EditorComboStyle}"
-                                                  MinWidth="200"
-                                                  Margin="0,0,0,12" />
-
-                                        <!-- Channel -->
-                                        <TextBlock Text="CANAL MIDI (1-16)" Style="{StaticResource SectionHeader}" />
-                                        <TextBox Text="{Binding Channel,
-                                                        UpdateSourceTrigger=LostFocus,
-                                                        ValidatesOnNotifyDataErrors=True}"
-                                                 Style="{StaticResource EditorTextBoxStyle}"
-                                                 Width="80" HorizontalAlignment="Left"
-                                                 Margin="0,0,0,12" />
+                                        <!-- Périphériques (multi-select) -->
+                                        <TextBlock Text="PÉRIPHÉRIQUES" Style="{StaticResource SectionHeader}" />
+                                        <ItemsControl ItemsSource="{Binding ProfileSelections}"
+                                                      Margin="0,0,0,12">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate>
+                                                    <CheckBox IsChecked="{Binding IsSelected}"
+                                                              Content="{Binding DisplayName}"
+                                                              Foreground="#CDD6F4"
+                                                              Margin="0,2" />
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
 
                                         <!-- Data1 -->
                                         <TextBlock Text="DATA 1 (0-127)" Style="{StaticResource SectionHeader}" />

--- a/src/LiveCompanion.UI/Views/EditorView.xaml
+++ b/src/LiveCompanion.UI/Views/EditorView.xaml
@@ -462,11 +462,19 @@
                     <DockPanel Margin="0,8,0,0">
                         <Border DockPanel.Dock="Top" Style="{StaticResource CardStyle}" Padding="20,8">
                             <StackPanel>
-                                <!-- Preset toolbar -->
+                                <!-- Profile + shortcut toolbar -->
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,0,6">
-                                    <TextBlock Text="PRESET" Foreground="#585B70" FontSize="11" FontWeight="Bold"
+                                    <TextBlock Text="PROFIL" Foreground="#585B70" FontSize="11" FontWeight="Bold"
                                                VerticalAlignment="Center" Margin="0,0,8,0" />
-                                    <ComboBox ItemsSource="{Binding MidiPresets}"
+                                    <ComboBox ItemsSource="{Binding MidiProfiles}"
+                                              SelectedItem="{Binding SelectedMidiProfile}"
+                                              DisplayMemberPath="Name"
+                                              Style="{StaticResource EditorComboStyle}"
+                                              MinWidth="140"
+                                              Margin="0,0,12,0" />
+                                    <TextBlock Text="RACCOURCI" Foreground="#585B70" FontSize="11" FontWeight="Bold"
+                                               VerticalAlignment="Center" Margin="0,0,8,0" />
+                                    <ComboBox ItemsSource="{Binding AvailablePresets}"
                                               SelectedItem="{Binding SelectedMidiPreset}"
                                               DisplayMemberPath="Name"
                                               Style="{StaticResource EditorComboStyle}"
@@ -475,13 +483,6 @@
                                     <Button Content="Appliquer"
                                             Command="{Binding ApplyMidiPresetCommand}"
                                             Style="{StaticResource ActionButtonStyle}" />
-                                    <Button Content="Sauver preset"
-                                            Command="{Binding SaveMidiEventAsPresetCommand}"
-                                            Style="{StaticResource ActionButtonStyle}" />
-                                    <Button Content="Suppr. preset"
-                                            Command="{Binding DeleteMidiPresetCommand}"
-                                            Style="{StaticResource ActionButtonStyle}"
-                                            Foreground="#F38BA8" />
                                 </StackPanel>
                                 <!-- Event actions -->
                                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">

--- a/src/LiveCompanion.UI/Views/EditorView.xaml
+++ b/src/LiveCompanion.UI/Views/EditorView.xaml
@@ -461,17 +461,41 @@
                 <TabItem Header="MIDI">
                     <DockPanel Margin="0,8,0,0">
                         <Border DockPanel.Dock="Top" Style="{StaticResource CardStyle}" Padding="20,8">
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                <Button Content="+ Ajouter"
-                                        Command="{Binding AddMidiEventCommand}"
-                                        Style="{StaticResource ActionButtonStyle}" />
-                                <Button Content="Supprimer"
-                                        Command="{Binding RemoveMidiEventCommand}"
-                                        Style="{StaticResource ActionButtonStyle}"
-                                        Foreground="#F38BA8" />
-                                <Button Content="Test"
-                                        Command="{Binding TestMidiEventCommand}"
-                                        Style="{StaticResource AccentButtonStyle}" />
+                            <StackPanel>
+                                <!-- Preset toolbar -->
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,0,6">
+                                    <TextBlock Text="PRESET" Foreground="#585B70" FontSize="11" FontWeight="Bold"
+                                               VerticalAlignment="Center" Margin="0,0,8,0" />
+                                    <ComboBox ItemsSource="{Binding MidiPresets}"
+                                              SelectedItem="{Binding SelectedMidiPreset}"
+                                              DisplayMemberPath="Name"
+                                              Style="{StaticResource EditorComboStyle}"
+                                              MinWidth="180"
+                                              Margin="0,0,6,0" />
+                                    <Button Content="Appliquer"
+                                            Command="{Binding ApplyMidiPresetCommand}"
+                                            Style="{StaticResource ActionButtonStyle}" />
+                                    <Button Content="Sauver preset"
+                                            Command="{Binding SaveMidiEventAsPresetCommand}"
+                                            Style="{StaticResource ActionButtonStyle}" />
+                                    <Button Content="Suppr. preset"
+                                            Command="{Binding DeleteMidiPresetCommand}"
+                                            Style="{StaticResource ActionButtonStyle}"
+                                            Foreground="#F38BA8" />
+                                </StackPanel>
+                                <!-- Event actions -->
+                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                    <Button Content="+ Ajouter"
+                                            Command="{Binding AddMidiEventCommand}"
+                                            Style="{StaticResource ActionButtonStyle}" />
+                                    <Button Content="Supprimer"
+                                            Command="{Binding RemoveMidiEventCommand}"
+                                            Style="{StaticResource ActionButtonStyle}"
+                                            Foreground="#F38BA8" />
+                                    <Button Content="Test"
+                                            Command="{Binding TestMidiEventCommand}"
+                                            Style="{StaticResource AccentButtonStyle}" />
+                                </StackPanel>
                             </StackPanel>
                         </Border>
 

--- a/tests/LiveCompanion.Tests/EngineReal/MidiEngineRealTests.cs
+++ b/tests/LiveCompanion.Tests/EngineReal/MidiEngineRealTests.cs
@@ -84,9 +84,9 @@ public class MidiEngineRealTests : IDisposable
     [Fact]
     public async Task SendEvent_WithoutInit_ShouldThrow()
     {
-        var evt = new MidiEvent { Type = MidiEventType.NoteOn, Channel = 1, Data1 = 60 };
+        var evt = new MidiEvent { Type = MidiEventType.NoteOn, Data1 = 60 };
 
-        var act = () => _engine.SendEventAsync(evt);
+        var act = () => _engine.SendEventAsync(evt, []);
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
@@ -95,26 +95,25 @@ public class MidiEngineRealTests : IDisposable
     {
         await _engine.InitializeAsync(new MidiConfig { SelectedPorts = [] });
 
-        var act = () => _engine.SendEventAsync(null!);
+        var act = () => _engine.SendEventAsync(null!, []);
         await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
     [Fact]
-    public async Task SendEvent_UnknownDevice_ShouldNotThrow()
+    public async Task SendEvent_UnknownProfile_ShouldNotThrow()
     {
         await _engine.InitializeAsync(new MidiConfig { SelectedPorts = [] });
 
         var evt = new MidiEvent
         {
             Type = MidiEventType.NoteOn,
-            Channel = 1,
+            ProfileIds = [Guid.NewGuid()],
             Data1 = 60,
             Data2 = 100,
-            DeviceOut = "UnknownDevice",
         };
 
-        // Should warn but not throw
-        await _engine.SendEventAsync(evt);
+        // Should warn but not throw (profile not found)
+        await _engine.SendEventAsync(evt, []);
     }
 
     // ------------------------------------------------------------------ //
@@ -128,7 +127,7 @@ public class MidiEngineRealTests : IDisposable
         await _engine.ShutdownAsync();
 
         var evt = new MidiEvent { Type = MidiEventType.NoteOn };
-        var act = () => _engine.SendEventAsync(evt);
+        var act = () => _engine.SendEventAsync(evt, []);
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
@@ -145,18 +144,9 @@ public class MidiEngineRealTests : IDisposable
     [Fact]
     public void BuildMidiMessage_NoteOn_ShouldBuildCorrectly()
     {
-        var evt = new MidiEvent
-        {
-            Type = MidiEventType.NoteOn,
-            Channel = 1,
-            Data1 = 60,  // middle C
-            Data2 = 100, // velocity
-        };
-
-        int msg = MidiEngineReal.BuildMidiMessage(evt);
+        int msg = MidiEngineReal.BuildMidiMessage(MidiEventType.NoteOn, 1, 60, 100);
 
         // Status = 0x90 (NoteOn ch1), Data1 = 60, Data2 = 100
-        // Format: status | (data1 << 8) | (data2 << 16)
         int expected = 0x90 | (60 << 8) | (100 << 16);
         msg.Should().Be(expected);
     }
@@ -164,15 +154,7 @@ public class MidiEngineRealTests : IDisposable
     [Fact]
     public void BuildMidiMessage_NoteOff_Channel10_ShouldBuildCorrectly()
     {
-        var evt = new MidiEvent
-        {
-            Type = MidiEventType.NoteOff,
-            Channel = 10,
-            Data1 = 36,
-            Data2 = 0,
-        };
-
-        int msg = MidiEngineReal.BuildMidiMessage(evt);
+        int msg = MidiEngineReal.BuildMidiMessage(MidiEventType.NoteOff, 10, 36, 0);
 
         // Status = 0x80 | 9 (channel 10 = index 9)
         int expected = (0x80 | 9) | (36 << 8) | (0 << 16);
@@ -182,15 +164,7 @@ public class MidiEngineRealTests : IDisposable
     [Fact]
     public void BuildMidiMessage_ControlChange_ShouldBuildCorrectly()
     {
-        var evt = new MidiEvent
-        {
-            Type = MidiEventType.ControlChange,
-            Channel = 1,
-            Data1 = 7,   // volume
-            Data2 = 127, // max
-        };
-
-        int msg = MidiEngineReal.BuildMidiMessage(evt);
+        int msg = MidiEngineReal.BuildMidiMessage(MidiEventType.ControlChange, 1, 7, 127);
 
         int expected = 0xB0 | (7 << 8) | (127 << 16);
         msg.Should().Be(expected);
@@ -199,15 +173,7 @@ public class MidiEngineRealTests : IDisposable
     [Fact]
     public void BuildMidiMessage_ProgramChange_ShouldHaveOnlyOneDataByte()
     {
-        var evt = new MidiEvent
-        {
-            Type = MidiEventType.ProgramChange,
-            Channel = 3,
-            Data1 = 42,
-            Data2 = 99, // should be ignored
-        };
-
-        int msg = MidiEngineReal.BuildMidiMessage(evt);
+        int msg = MidiEngineReal.BuildMidiMessage(MidiEventType.ProgramChange, 3, 42, 99);
 
         // ProgramChange: status | (data1 << 8) — no data2
         int expected = (0xC0 | 2) | (42 << 8);
@@ -218,28 +184,18 @@ public class MidiEngineRealTests : IDisposable
     public void BuildMidiMessage_ShouldClampChannel()
     {
         // Channel 0 → clamped to 1 → index 0
-        var evtLow = new MidiEvent { Type = MidiEventType.NoteOn, Channel = 0, Data1 = 60, Data2 = 100 };
-        int msgLow = MidiEngineReal.BuildMidiMessage(evtLow);
+        int msgLow = MidiEngineReal.BuildMidiMessage(MidiEventType.NoteOn, 0, 60, 100);
         (msgLow & 0x0F).Should().Be(0, "channel 0 should be clamped to 1 (index 0)");
 
         // Channel 17 → clamped to 16 → index 15
-        var evtHigh = new MidiEvent { Type = MidiEventType.NoteOn, Channel = 17, Data1 = 60, Data2 = 100 };
-        int msgHigh = MidiEngineReal.BuildMidiMessage(evtHigh);
+        int msgHigh = MidiEngineReal.BuildMidiMessage(MidiEventType.NoteOn, 17, 60, 100);
         (msgHigh & 0x0F).Should().Be(15, "channel 17 should be clamped to 16 (index 15)");
     }
 
     [Fact]
     public void BuildMidiMessage_ShouldClampDataValues()
     {
-        var evt = new MidiEvent
-        {
-            Type = MidiEventType.NoteOn,
-            Channel = 1,
-            Data1 = 200,  // > 127, should clamp
-            Data2 = -10,  // < 0, should clamp
-        };
-
-        int msg = MidiEngineReal.BuildMidiMessage(evt);
+        int msg = MidiEngineReal.BuildMidiMessage(MidiEventType.NoteOn, 1, 200, -10);
 
         int data1 = (msg >> 8) & 0x7F;
         int data2 = (msg >> 16) & 0x7F;
@@ -252,8 +208,7 @@ public class MidiEngineRealTests : IDisposable
     {
         for (int ch = 1; ch <= 16; ch++)
         {
-            var evt = new MidiEvent { Type = MidiEventType.NoteOn, Channel = ch };
-            int msg = MidiEngineReal.BuildMidiMessage(evt);
+            int msg = MidiEngineReal.BuildMidiMessage(MidiEventType.NoteOn, ch, 0, 0);
             (msg & 0x0F).Should().Be(ch - 1, $"channel {ch} should map to index {ch - 1}");
         }
     }

--- a/tests/LiveCompanion.Tests/Mocks/MidiEngineMockTests.cs
+++ b/tests/LiveCompanion.Tests/Mocks/MidiEngineMockTests.cs
@@ -18,6 +18,13 @@ public class MidiEngineMockTests
         SelectedPorts = { "MockMIDI Port 1" },
     };
 
+    private static MidiProfile TestProfile => new()
+    {
+        Name = "Test Device",
+        DeviceOut = "MockMIDI Port 1",
+        DefaultChannel = 1,
+    };
+
     [Fact]
     public async Task Initialize_ShouldSucceed()
     {
@@ -41,9 +48,10 @@ public class MidiEngineMockTests
     public async Task SendEvent_WithoutInit_ShouldThrow()
     {
         var engine = CreateEngine();
-        var evt = new MidiEvent { Type = MidiEventType.NoteOn, Channel = 1, Data1 = 60 };
+        var profile = TestProfile;
+        var evt = new MidiEvent { Type = MidiEventType.NoteOn, ProfileIds = [profile.Id], Data1 = 60 };
 
-        var act = () => engine.SendEventAsync(evt);
+        var act = () => engine.SendEventAsync(evt, [profile]);
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
@@ -53,33 +61,63 @@ public class MidiEngineMockTests
         var engine = CreateEngine();
         await engine.InitializeAsync(DefaultConfig);
 
+        var profile = TestProfile;
         var evt = new MidiEvent
         {
             Type = MidiEventType.ControlChange,
-            Channel = 1,
+            ProfileIds = [profile.Id],
             Data1 = 7,
             Data2 = 100,
-            DeviceOut = "MockMIDI Port 1",
         };
 
-        await engine.SendEventAsync(evt);
+        await engine.SendEventAsync(evt, [profile]);
 
         engine.SentEvents.Should().ContainSingle();
         engine.SentEvents[0].Type.Should().Be(MidiEventType.ControlChange);
         engine.SentEvents[0].Data1.Should().Be(7);
+        engine.SentEvents[0].DeviceOut.Should().Be("MockMIDI Port 1");
+        engine.SentEvents[0].Channel.Should().Be(1);
     }
 
     [Fact]
-    public async Task SendEvent_MultipleSends_ShouldAccumulate()
+    public async Task SendDirect_ShouldRecordEvent()
     {
         var engine = CreateEngine();
         await engine.InitializeAsync(DefaultConfig);
 
-        await engine.SendEventAsync(new MidiEvent { Type = MidiEventType.NoteOn });
-        await engine.SendEventAsync(new MidiEvent { Type = MidiEventType.NoteOff });
-        await engine.SendEventAsync(new MidiEvent { Type = MidiEventType.ProgramChange });
+        await engine.SendDirectAsync(MidiEventType.NoteOn, "MockMIDI Port 1", 5, 60, 100);
 
-        engine.SentEvents.Should().HaveCount(3);
+        engine.SentEvents.Should().ContainSingle();
+        engine.SentEvents[0].Type.Should().Be(MidiEventType.NoteOn);
+        engine.SentEvents[0].DeviceOut.Should().Be("MockMIDI Port 1");
+        engine.SentEvents[0].Channel.Should().Be(5);
+        engine.SentEvents[0].Data1.Should().Be(60);
+    }
+
+    [Fact]
+    public async Task SendEvent_MultipleProfiles_ShouldSendToEach()
+    {
+        var engine = CreateEngine();
+        await engine.InitializeAsync(DefaultConfig);
+
+        var profile1 = new MidiProfile { Name = "Device A", DeviceOut = "MockMIDI Port 1", DefaultChannel = 1 };
+        var profile2 = new MidiProfile { Name = "Device B", DeviceOut = "MockMIDI Port 2", DefaultChannel = 10 };
+
+        var evt = new MidiEvent
+        {
+            Type = MidiEventType.ControlChange,
+            ProfileIds = [profile1.Id, profile2.Id],
+            Data1 = 7,
+            Data2 = 127,
+        };
+
+        await engine.SendEventAsync(evt, [profile1, profile2]);
+
+        engine.SentEvents.Should().HaveCount(2);
+        engine.SentEvents[0].DeviceOut.Should().Be("MockMIDI Port 1");
+        engine.SentEvents[0].Channel.Should().Be(1);
+        engine.SentEvents[1].DeviceOut.Should().Be("MockMIDI Port 2");
+        engine.SentEvents[1].Channel.Should().Be(10);
     }
 
     [Fact]
@@ -87,14 +125,14 @@ public class MidiEngineMockTests
     {
         var engine = CreateEngine();
         await engine.InitializeAsync(DefaultConfig);
-        await engine.SendEventAsync(new MidiEvent { Type = MidiEventType.NoteOn });
+        await engine.SendDirectAsync(MidiEventType.NoteOn, "MockMIDI Port 1", 1, 60, 100);
 
         await engine.ShutdownAsync();
 
         engine.SentEvents.Should().BeEmpty();
 
         // After shutdown, send should throw
-        var act = () => engine.SendEventAsync(new MidiEvent { Type = MidiEventType.NoteOn });
+        var act = () => engine.SendDirectAsync(MidiEventType.NoteOn, "MockMIDI Port 1", 1, 60, 100);
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
 
@@ -104,7 +142,7 @@ public class MidiEngineMockTests
         var engine = CreateEngine();
         await engine.InitializeAsync(DefaultConfig);
 
-        var act = () => engine.SendEventAsync(null!);
+        var act = () => engine.SendEventAsync(null!, []);
         await act.Should().ThrowAsync<ArgumentNullException>();
     }
 

--- a/tests/LiveCompanion.Tests/Mocks/TimelineSchedulerMockTests.cs
+++ b/tests/LiveCompanion.Tests/Mocks/TimelineSchedulerMockTests.cs
@@ -272,13 +272,19 @@ public class TimelineSchedulerMockTests : IDisposable
         var midiEngine = new MidiEngineMock(_log);
         await midiEngine.InitializeAsync(new MidiConfig { SelectedPorts = { "MockMIDI Port 1" } });
 
-        using var scheduler = new TimelineSchedulerMock(_log, midiEngine: midiEngine);
+        var projectStore = new ProjectStoreMock(_log);
+        var profile = new MidiProfile { Name = "Test", DeviceOut = "MockMIDI Port 1", DefaultChannel = 1 };
+        var settings = projectStore.GetSettings();
+        settings.MidiProfiles.Add(profile);
+        projectStore.SaveSettings(settings);
+
+        using var scheduler = new TimelineSchedulerMock(_log, midiEngine: midiEngine, projectStore: projectStore);
 
         var song = CreateTestSong(sectionCount: 1, barsPerSection: 2, tempo: 600);
         song.MidiEvents.Add(new MidiEvent
         {
             Type = MidiEventType.ProgramChange,
-            Channel = 1,
+            ProfileIds = [profile.Id],
             Data1 = 42,
             Position = TimelinePosition.Zero,
         });

--- a/tests/LiveCompanion.Tests/Models/MidiEventTests.cs
+++ b/tests/LiveCompanion.Tests/Models/MidiEventTests.cs
@@ -13,8 +13,7 @@ public class MidiEventTests
 
         evt.Id.Should().NotBe(Guid.Empty);
         evt.Type.Should().Be(MidiEventType.ProgramChange);
-        evt.DeviceOut.Should().BeEmpty();
-        evt.Channel.Should().Be(1);
+        evt.ProfileIds.Should().BeEmpty();
         evt.Data1.Should().Be(0);
         evt.Data2.Should().Be(0);
         evt.Position.Should().Be(TimelinePosition.Zero);
@@ -23,20 +22,19 @@ public class MidiEventTests
     [Fact]
     public void MidiEvent_CanSetAllProperties()
     {
+        var profileId = Guid.NewGuid();
         var pos = new TimelinePosition(1, 2, 3, 0);
         var evt = new MidiEvent
         {
             Type = MidiEventType.ControlChange,
-            DeviceOut = "MockMIDI Port 1",
-            Channel = 10,
+            ProfileIds = [profileId],
             Data1 = 7,
             Data2 = 100,
             Position = pos,
         };
 
         evt.Type.Should().Be(MidiEventType.ControlChange);
-        evt.DeviceOut.Should().Be("MockMIDI Port 1");
-        evt.Channel.Should().Be(10);
+        evt.ProfileIds.Should().ContainSingle().Which.Should().Be(profileId);
         evt.Data1.Should().Be(7);
         evt.Data2.Should().Be(100);
         evt.Position.Should().Be(pos);

--- a/tests/LiveCompanion.Tests/Models/SongTests.cs
+++ b/tests/LiveCompanion.Tests/Models/SongTests.cs
@@ -79,7 +79,7 @@ public class SongTests
     public void Song_CanAddMidiEvents()
     {
         var song = new Song();
-        var evt = new MidiEvent { Type = MidiEventType.ProgramChange, Channel = 1, Data1 = 42 };
+        var evt = new MidiEvent { Type = MidiEventType.ProgramChange, Data1 = 42 };
 
         song.MidiEvents.Add(evt);
 

--- a/tests/LiveCompanion.Tests/Validation/ModelValidatorTests.cs
+++ b/tests/LiveCompanion.Tests/Validation/ModelValidatorTests.cs
@@ -180,24 +180,6 @@ public class ModelValidatorTests
     // ------------------------------------------------------------------ //
 
     [Theory]
-    [InlineData(0)]
-    [InlineData(17)]
-    [InlineData(-1)]
-    public void ValidateSong_MidiChannelOutOfRange_ShouldReturnError(int channel)
-    {
-        var song = new Song
-        {
-            Title = "Test",
-            MidiEvents = { new MidiEvent { Channel = channel } },
-        };
-
-        var result = ModelValidator.ValidateSong(song);
-
-        result.IsValid.Should().BeFalse();
-        result.Issues.Should().Contain(i => i.Field.Contains("Channel"));
-    }
-
-    [Theory]
     [InlineData(-1)]
     [InlineData(128)]
     public void ValidateSong_MidiData1OutOfRange_ShouldReturnError(int data1)
@@ -205,7 +187,7 @@ public class ModelValidatorTests
         var song = new Song
         {
             Title = "Test",
-            MidiEvents = { new MidiEvent { Channel = 1, Data1 = data1 } },
+            MidiEvents = { new MidiEvent { Data1 = data1 } },
         };
 
         var result = ModelValidator.ValidateSong(song);
@@ -222,7 +204,7 @@ public class ModelValidatorTests
         var song = new Song
         {
             Title = "Test",
-            MidiEvents = { new MidiEvent { Channel = 1, Data2 = data2 } },
+            MidiEvents = { new MidiEvent { Data2 = data2 } },
         };
 
         var result = ModelValidator.ValidateSong(song);
@@ -376,7 +358,7 @@ public class ModelValidatorTests
         var song = new Song
         {
             Title = "Test",
-            MidiEvents = { new MidiEvent { Channel = 1, Data1 = 0, Data2 = 127 } },
+            MidiEvents = { new MidiEvent { Data1 = 0, Data2 = 127 } },
         };
 
         ModelValidator.ValidateSong(song).IsValid.Should().BeTrue();


### PR DESCRIPTION
## Summary
This PR introduces a MIDI profiles system that allows users to create device-specific profiles with predefined MIDI shortcuts. Instead of assigning MIDI events directly to ports and channels, events now reference one or more profiles, which handle the actual port and channel routing.

## Key Changes

### New Models
- **`MidiProfile`**: Represents a MIDI device (e.g., "Quad Cortex") with:
  - Name, associated output port, default MIDI channel
  - Collection of reusable `MidiPreset` shortcuts
- **`MidiPreset`**: Reusable MIDI shortcut containing type, data1, and data2 (no position or device info)

### Core Architecture Changes
- **`MidiEvent`**: Refactored to use `ProfileIds` (list of GUIDs) instead of direct `DeviceOut` and `Channel` properties
- **`IMidiEngine.SendEventAsync()`**: Now accepts profiles list to resolve routing at send time
- **`IMidiEngine.SendDirectAsync()`**: New method for direct port/channel sends (used in config testing)

### UI Changes
- **ConfigView**: New "PROFILS MIDI" section allowing users to:
  - Create/delete/rename profiles
  - Assign MIDI ports and default channels
  - Add/remove presets within each profile
- **EditorView**: Added profile and preset selection toolbar above MIDI events
  - Users can select a profile and apply its presets to events
  - `ApplyMidiPresetCommand` populates event data from selected preset

### ViewModel Updates
- **`ConfigViewModel`**: Manages profile CRUD operations and persistence
- **`EditorViewModel`**: 
  - Loads profiles from settings
  - Exposes available presets based on selected profile
  - Refreshes profile list when returning from config
- **`MidiEventViewModel`**: 
  - Replaced device/channel fields with multi-select profile checkboxes
  - `ProfileSelectionItem` helper class for checkbox binding
  - `RefreshProfiles()` method to sync with config changes

### Engine Implementation
- **`MidiEngineReal` & `MidiEngineMock`**: 
  - `SendEventAsync()` now iterates through referenced profiles and sends to each
  - Extracted message building to `SendToPort()` helper
  - Updated `BuildMidiMessage()` signature to accept individual parameters

### Persistence
- Profiles stored in `AppSettings.MidiProfiles`
- Automatically loaded on app startup and when config is saved

### Testing
- Updated unit tests to use new profile-based API
- Added tests for multi-profile event sending
- Removed channel validation tests (now profile-level concern)

## Implementation Details
- Profile IDs are GUIDs, allowing stable references even if names change
- Events can target multiple profiles (useful for synchronized multi-device setups)
- Presets are profile-specific but can be quickly applied to events via UI
- Default channel is profile-level, reducing per-event configuration

https://claude.ai/code/session_011Vr6yo8gQBBsZzafxMRs4Y